### PR TITLE
cmd/age: initial support for SSH identities and recipients

### DIFF
--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/FiloSottile/age/internal/age"
@@ -89,7 +90,17 @@ func decrypt() {
 	var identities []age.Identity
 	// TODO: use the default location if no arguments are provided.
 	for _, name := range flag.Args() {
-		ids, err := parseIdentitiesFile(name)
+		var (
+			ids []age.Identity
+			err error
+		)
+
+		// TODO: smarter detection logic than looking for .ssh/* in the path.
+		if filepath.Base(filepath.Dir(name)) == ".ssh" {
+			ids, err = parseSSHIdentity(name)
+		} else {
+			ids, err = parseIdentitiesFile(name)
+		}
 		if err != nil {
 			log.Fatalf("Error: %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This is primitive and only currently accepts SSH recipients via public key text (rather than file), but it seems to work!

```
$ echo "hello SSH" | ./age "`cat test_rsa.pub`" "`cat test_ed25519.pub`" | tee ssh.age
This is a file encrypted with age-tool.com, version 1
-> ssh-rsa X2Vtsw
h5ntTt0PEBcZgtgtjGu0Gxj1DtbJqLVt-9MrYmsgGxNPIy9kL3Dn5vJf61axbBo0OyjBUtSGvpXXRYFazJfWuIj1LeJhnCyK0jLZ5dRPDrVNtT1NqMzlY_Lh9IiNg-V37FLWxCJOkmDO7yYz1URRSnRiurgVfj--emUaBvvc0053ABWE7WOTlmHssQOp8dnjrh3Q6lsOeklLsHnLtahkOS8lqmPs0GH3bx--0calWABTGYktXr3-YJz8-i19b4a-IHBo57BYI3XT9p8KC4dHOdUdt_1r0jriZmdpSj2_2Z3vAdvzH8LbOaXDh1A76ec1LuQL63SUKNEHTChuShi3qg
-> ssh-ed25519 lSfeAQ gwegE4mWBU82XFV3U_9TUY_fZLV1Ps81kLWIcCmFGTA
J355AxSwjGDogzlNxY0yrCRtSNSJ7BNreC5GsmRlUB8
--- JvzsD08j5Cb4gp-sY3470SRZfc90T4KZLN_JPlpzoQw
Kp9&;ZBRP@y0u
$ ./age -d ~/.ssh/test_ed25519 < ssh.age 
hello SSH
$ ./age -d ~/.ssh/test_rsa < ssh.age 
hello SSH
```

As discussed, I know the APIs are a WIP and am happy to make adjustments or rebase my changes as needed.

Fixes #3.