### PR TITLE
Add the -i, -o flags, and other improvements

### DIFF
--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -26,16 +26,14 @@ func main() {
 	decryptFlag := flag.Bool("d", false, "decrypt the input")
 	flag.Parse()
 
+	if *generateFlag && *decryptFlag {
+		log.Fatalf("Invalid flag combination")
+	}
+
 	switch {
 	case *generateFlag:
-		if *decryptFlag {
-			log.Fatalf("Invalid flag combination")
-		}
 		generate()
 	case *decryptFlag:
-		if *generateFlag {
-			log.Fatalf("Invalid flag combination")
-		}
 		decrypt()
 	default:
 		encrypt()


### PR DESCRIPTION
- Only check for invalid flag combinations once, outside the switch.
- Pass os.Files for each function instead of using stdin/stderr by default.

The last comment replaces the use of fmt.Printf with file.WriteString. This *may* fix #2, but I don't have a Windows system on hand to check.