### PR TITLE
Decrypt private keys encrypted with passphrase.

### DIFF
--- a/cmd/age/parse.go
+++ b/cmd/age/parse.go
@@ -82,7 +82,7 @@ func parseSSHIdentity(name string, f io.Reader) ([]age.Identity, error) {
 		return nil, fmt.Errorf("failed to read %q: %v", name, err)
 	}
 
-	id, err := age.ParseSSHIdentity(pemBytes)
+	id, err := age.ParseSSHIdentity(name, pemBytes)
 	if err != nil {
 		return nil, fmt.Errorf("malformed SSH identity in %q: %v", name, err)
 	}

--- a/internal/age/ssh.go
+++ b/internal/age/ssh.go
@@ -281,14 +281,14 @@ func NewSSHEd25519Identity(key ed25519.PrivateKey) (*SSHEd25519Identity, error) 
 	return i, nil
 }
 
-func ParseSSHIdentity(pemBytes []byte) (Identity, error) {
+func ParseSSHIdentity(name string, pemBytes []byte) (Identity, error) {
 	k, err := ssh.ParseRawPrivateKey(pemBytes)
 	if err != nil {
 		if !strings.Contains(err.Error(), "cannot decode encrypted private keys") {
 			return nil, err
 		}
 
-		fmt.Print("Enter passphrase for encrypted id_rsa: ")
+		fmt.Printf("Enter passphrase for key '%s': ", name)
 		pass, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Println()
 

--- a/internal/age/ssh.go
+++ b/internal/age/ssh.go
@@ -7,7 +7,6 @@
 package age
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -26,6 +25,7 @@ import (
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const oaepLabel = "age-tool.com ssh-rsa"
@@ -289,11 +289,8 @@ func ParseSSHIdentity(pemBytes []byte) (Identity, error) {
 		}
 
 		fmt.Print("Enter passphrase for encrypted id_rsa: ")
-
-		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-
-		pass := strings.TrimSuffix(input, "\n")
+		pass, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Println()
 
 		k, err = ssh.ParseRawPrivateKeyWithPassphrase(pemBytes, []byte(pass))
 		if err != nil {


### PR DESCRIPTION
This allows one to decrypt age messages encrypted with a `id_rsa.pub` that is associated with a an encrypted `id_rsa` key.

```
$ ./age -d -i /tmp/secret.age ~/.ssh/id_rsa
Enter passphrase for encrypted id_rsa:
```