### PR TITLE
Installation: mention Linux for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Multiple keys can be provided, and any unused ones will be ignored.
 
 ## Installation
 
-On macOS, you can use Homebrew:
+On macOS or Linux, you can use Homebrew:
 
 ```
 brew tap filippo.io/age https://filippo.io/age


### PR DESCRIPTION
Since Homebrew now works on linux (https://docs.brew.sh/Homebrew-on-Linux), you can use the same installation steps for Linux as you would for macOS. I tested this on Ubuntu 19.10.