### PR TITLE
Add QR Code Generation to keygen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module filippo.io/age
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
+require (
+	github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086
+	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
+)
 
 replace golang.org/x/crypto => github.com/Filosottile/go v0.0.0-20191122011136-9090b284250b

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Filosottile/go v0.0.0-20191122011136-9090b284250b h1:4AVIiSN9FRvfh7Oq7NhMHoU4oDhNkpfq4q9prQNlq7k=
 github.com/Filosottile/go v0.0.0-20191122011136-9090b284250b/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086 h1:RYiqpb2ii2Z6J4x0wxK46kvPBbFuZcdhS+CIztmYgZs=
+github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086/go.mod h1:PLPIyL7ikehBD1OAjmKKiOEhbvWyHGaNDjquXMcYABo=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This change adds a new flag to the `keygen` command (`-q`) that produces a QR code from the public key. This is useful as it provides a simple way to transfer the public key, especially to mobile applications (which I'm interested in doing for another project I'm working on). In the case of mobile applications, this is quite a bit easier, and less error prone, than manual entry of the public key.

This uses the [go-qrcode](https://github.com/skip2/go-qrcode) package to produce the QR code and generate the string that is printed to the console. 

This does not write the QR code to a file, if the output is being written to a file (via `-o`), this will print the QR code to `os.Stderr`, matching the existing public key behavior of the `generate` method.

This produces a "small" QR code, or at least the smallest that can reasonably be done for console output; here is a sample of the output, with all output going to the console (`-o` not used):

```
# created: 2019-12-28T17:20:16-05:00
# public key: age1gaqle5vafy4aqcrw6pakc9c892ph3jkjd3c9cx7r24xhm27zkupq5nrehn
public key QR code:
█████████████████████████████████████████
█████████████████████████████████████████
████ ▄▄▄▄▄ █▀ █▀▀▀▀█▄▀ ▀▀ ▄█▄█ ▄▄▄▄▄ ████
████ █   █ █▀ ▄ █▀▄▀ ▀█▄  █▄ █ █   █ ████
████ █▄▄▄█ █▀█ █▄▀▀  ▀█▄██▀▄██ █▄▄▄█ ████
████▄▄▄▄▄▄▄█▄█▄█ █▄█▄█▄▀ ▀ █ █▄▄▄▄▄▄▄████
████  ▄▄▄█▄   ▄█▄█  ▄▄ █▄█  ▀▄▀▄█ ▀▄▀████
████▀█  █▀▄ ▀ ▀ ▄ ▄▄ ▄▄ ▄ ▄▀▀▀█▄█ ▀ █████
████▄ ▀▀█ ▄▄▄▄▀▄▀██ █▄ ▀▄ ▄▀▄ ▀▀▄█▀▀▀████
████ ▄▀▀▀▄▄█▀█▀█▀ ▄▄ ▄▄▀▀▀█▀▀▀█▀▀  ▀█████
████▀██▄▀█▄█ ▀▄█▄▄▄  █▀▀▄ █ ▄▄▀█▄▄▀▄▀████
████▄█ ▄▄█▄▄▀▄▄ ▄██▄  █▀▄▀ █▀▀▀▄▄   ▀████
████▀█  ▀▀▄█ ▀█▄▀▀█▄▄█ █▀ █▀▄ ▀▄▄▀█▄▀████
████ █▄█ ▄▄ ▄  █▀ ▄█▀ ▀▀▀█▄█ █▀▀█▀  █████
████▄█▄█▄█▄▄  ▄█▄█▄▄██ ▀█ █▀ ▄▄▄ ▀▀█▀████
████ ▄▄▄▄▄ █▄▄▀ ▄█▀█  ▀ ▀▀▀  █▄█ ▄  ▀████
████ █   █ █  █▄▀▀▀▄ ██▀▄▀▀█▄ ▄   ▀▀▄████
████ █▄▄▄█ █ ▄██▀ ▄▄▄▄▄ ▀█▄ ▄ ▄▀▀  ██████
████▄▄▄▄▄▄▄█▄███▄█▄▄█▄▄█████▄▄▄██▄█▄█████
█████████████████████████████████████████
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

AGE-SECRET-KEY-1S269XL94KFEKRJP0YX8RZTTLQU4494UF33TRZNUZ8QXYMN73WDAS8STDD8
```

If there are any questions, or any improvements needed, I would be happy to address any feedback.