### PR TITLE
.cirrus.yml: enable Cirrus-CI for FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+freebsd_12_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  install_script: pkg install -y go
+  build_script: go build -v ./...
+  test_script: go test -v ./...


### PR DESCRIPTION
Example run: https://cirrus-ci.com/build/5764596254375936
