### PR TITLE
Fixing a small typo in the SSH Keys section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ As a convenience feature, age also supports encrypting to `ssh-rsa` and `ssh-ed2
 $ cat ~/.ssh/id_ed25519.pub
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIZDRcvS8PnhXr30WKSKmf7WKKi92ACUa5nW589WukJz filippo@Bistromath.local
 $ age -r "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIZDRcvS8PnhXr30WKSKmf7WKKi92ACUa5nW589WukJz" example.jpg > example.jpg.age
-$ age -i ~/.ssh/id_ed25519 -d example.jpg.age > example.jpg
+$ age -d -i ~/.ssh/id_ed25519 example.jpg.age > example.jpg
 ```
 
 Note that SSH key support employs more complex cryptography, and embeds a public key tag in the encrypted file, making it possible to track files that are encrypted to a specific public key.


### PR DESCRIPTION
Without the `-d` option, the command gives the following error: 

```
Error: -i/--identity can't be used in encryption mode.
Did you forget to specify -d/--decrypt?
[ Did age not do what you expected? Could an error be more useful? Tell us: https://filippo.io/age/report ]
```

Hope this helps!