### PR TITLE
internal/age: enforce same limit as Decrypt function does

### DIFF
--- a/age.go
+++ b/age.go
@@ -75,6 +75,9 @@ func Encrypt(dst io.Writer, recipients ...Recipient) (io.WriteCloser, error) {
 	if len(recipients) == 0 {
 		return nil, errors.New("no recipients specified")
 	}
+	if len(recipients) > 20 {
+		return nil, errors.New("too many recipients")
+	}
 
 	fileKey := make([]byte, 16)
 	if _, err := rand.Read(fileKey); err != nil {


### PR DESCRIPTION
Decrypt function limits the recipient list to 20, should't Encrypt do the same or one could discover that they can't actually decrypt the data they encrypted?

```
$ age -d -i key < data-39-recipients
Error: too many recipients
[ Did age not do what you expected? Could an error be more useful? Tell us: https://filippo.io/age/report ]
```