### PR TITLE
increase decryption recipient limit from 20 to 1000

### DIFF
--- a/age.go
+++ b/age.go
@@ -124,8 +124,8 @@ func Decrypt(src io.Reader, identities ...Identity) (io.Reader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read header: %v", err)
 	}
-	if len(hdr.Recipients) > 20 {
-		return nil, errors.New("too many recipients")
+	if len(hdr.Recipients) > 1000 {
+		return nil, errors.New("refusing to decrypt for more than 1000 recipients")
 	}
 
 	var fileKey []byte


### PR DESCRIPTION
closes #139 

I tested decrypting my file with 69 recipients and it worked.