### PR TITLE
Use explicit conversion to avoid go-test error

### DIFF
--- a/internal/bech32/bech32_test.go
+++ b/internal/bech32/bech32_test.go
@@ -43,7 +43,7 @@ func TestBech32(t *testing.T) {
 		{"split1a2y9w", false},      // too short data part
 		{"1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false}, // empty hrp
 		// invalid character (DEL) in hrp
-		{"spl" + string(127) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},
+		{"spl" + string(rune(127)) + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false},
 		// too long
 		{"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j", false},
 


### PR DESCRIPTION
Fixes #138