### PR TITLE
age: add missing -p to usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An alternative interoperable Rust implementation is available at [github.com/str
 
 ```
 Usage:
-    age -r RECIPIENT [-a] [-o OUTPUT] [INPUT]
+    age -r RECIPIENT [-a] [-p] [-o OUTPUT] [INPUT]
     age --decrypt [-i KEY] [-o OUTPUT] [INPUT]
 
 Options:

--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -31,7 +31,7 @@ func (f *multiFlag) Set(value string) error {
 }
 
 const usage = `Usage:
-    age -r RECIPIENT [-a] [-o OUTPUT] [INPUT]
+    age -r RECIPIENT [-a] [-p] [-o OUTPUT] [INPUT]
     age --decrypt [-i KEY] [-o OUTPUT] [INPUT]
 
 Options:


### PR DESCRIPTION
I was initially not sure, whether this flag should only be used for encryption or for both encryption and decryption. This change would have prevented my confusion.