### PR TITLE
cmd/age: Improve decision on when to buffer output

### DIFF
--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -174,13 +174,6 @@ func main() {
 		defer f.Close()
 		out = f
 	} else if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		if armorFlag {
-			// If the output will go to a TTY, and it will be armored, buffer it
-			// up so it doesn't get in the way of typing the input.
-			buf := &bytes.Buffer{}
-			defer func() { io.Copy(os.Stdout, buf) }()
-			out = buf
-		}
 		if name != "-" {
 			if decryptFlag {
 				// TODO: buffer the output and check it's printable.
@@ -190,6 +183,13 @@ func main() {
 				logFatalf("Error: refusing to output binary to the terminal.\n" +
 					`Did you mean to use -a/--armor? Force with "-o -".`)
 			}
+		}
+		if in == os.Stdin && terminal.IsTerminal(int(os.Stdin.Fd())) {
+			// If the input comes from a TTY and output will go to a TTY,
+			// buffer it up so it doesn't get in the way of typing the input.
+			buf := &bytes.Buffer{}
+			defer func() { io.Copy(os.Stdout, buf) }()
+			out = buf
 		}
 	}
 

--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -180,13 +180,16 @@ func main() {
 			buf := &bytes.Buffer{}
 			defer func() { io.Copy(os.Stdout, buf) }()
 			out = buf
-		} else if decryptFlag && name != "-" {
-			// TODO: buffer the output and check it's printable.
-		} else if name != "-" {
-			// If the output wouldn't be armored, refuse to send binary to the
-			// terminal unless explicitly requested with "-o -".
-			logFatalf("Error: refusing to output binary to the terminal.\n" +
-				`Did you mean to use -a/--armor? Force with "-o -".`)
+		}
+		if name != "-" {
+			if decryptFlag {
+				// TODO: buffer the output and check it's printable.
+			} else if !armorFlag  {
+				// If the output wouldn't be armored, refuse to send binary to
+				// the terminal unless explicitly requested with "-o -".
+				logFatalf("Error: refusing to output binary to the terminal.\n" +
+					`Did you mean to use -a/--armor? Force with "-o -".`)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously output was buffered when `--armor` was set and the output was a TTY. It was not checked whether the input was a TTY, decryption was not taken into account and binary output was not buffered either. This lead to some problems:

1.: `dd if=/dev/urandom bs=1M count=300 | age -r age1... -a` caused `fatal error: runtime: out of memory` (increase count if it doesn't for you). No one will encrypt this much to stdout, but buffering is unnecessary here.

2.: Output was not buffered for `age -d` (when pasting some armored input into the TTY as input). Admittedly this only happens when copy and pasting a lot of input (ca. 70k bytes for me), but it still seems wrong. Here is how I can make the problem visible:
```
yes 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' \
| dd bs=1k count=70 \
| age -a -r age1... \
| xclip -i

# Paste with middle mouse button here:
age -d -i mykey
```

3.: Output was not buffered when encrypting and forcing binary output with `age -r age1... -o -`. Of course this is also something most people wouldn't do.