### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ On Arch Linux, age is available in the official repositories:
 sudo pacman -Syu age
 ```
 
+On Fedora 33 and later, [`age`](https://src.fedoraproject.org/rpms/age) is available through `dnf`:
+
+```
+dnf install age
+```
+
 On OpenBSD -current and 6.7+, you can use the port:
 
 ```


### PR DESCRIPTION
I read an article in [latacora](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html) about GPG shortcomings and it mentioned Age at the end. Since it was not yet packaged or Fedora I decided to add it. It should be available within 10 days after a period in testing.