### PR TITLE
cmg/age: explicitly set output file in tar example

### DIFF
--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -63,7 +63,7 @@ will be ignored. "-" may be used to read identities from standard input.
 Example:
     $ age-keygen -o key.txt
     Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
-    $ tar cvz ~/data | age -r age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p > data.tar.gz.age
+    $ tar cvzf - ~/data | age -r age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p > data.tar.gz.age
     $ age --decrypt -i key.txt -o data.tar.gz data.tar.gz.age`
 
 // Version can be set at link time to override debug.BuildInfo.Main.Version,


### PR DESCRIPTION
On some systems (e.g., OpenBSD) stdout is not the default output for tar. Even on Linux the default if the environment variable TAPE is not set is the compiled-in default (which often is stdout, but doesn't have to be).

This commit changes the example to make it work accross a wider range of systems.