### PR TITLE
Add armv7 to age builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
             if [ "$GOOS" == "windows" ]; then
               ( cd "$DIR"; zip age.zip -r age )
               mv "$DIR/age.zip" "age-$VERSION-$GOOS-$GOARCH.zip"
+            elif [ "$GOARCH" == "arm" ]; then
+              tar -cvzf "age-$VERSION-$GOOS-${GOARCH}v${GOARM}.tar.gz" -C "$DIR" age
             else
               tar -cvzf "age-$VERSION-$GOOS-$GOARCH.tar.gz" -C "$DIR" age
             fi
@@ -37,6 +39,7 @@ jobs:
           export CGO_ENABLED=0
           GOOS=linux GOARCH=amd64 build_age
           GOOS=linux GOARCH=arm GOARM=6 build_age
+          GOOS=linux GOARCH=arm GOARM=7 build_age
           GOOS=linux GOARCH=arm64 build_age
           GOOS=darwin GOARCH=amd64 build_age
           GOOS=windows GOARCH=amd64 build_age


### PR DESCRIPTION
armv7 is currently used in the raspberry pi 4 series to an extent; while its hardware supports arm64 (to my knowledge), distribution support is not yet complete.  having armv7 distributions also available will better support low-power hardware like the pi4 better.

as a side-effect, the arm version needs to also be distinguished in the artifact name. resulting artifacts would now be named "armv6" or "armv7" instead of just "arm".