### PR TITLE
README: mention official Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,10 @@ git clone https://filippo.io/age && cd age
 go build -o . filippo.io/age/cmd/...
 ```
 
-On Arch Linux, age is available from AUR as [`age`](https://aur.archlinux.org/packages/age/) or [`age-git`](https://aur.archlinux.org/packages/age-git/):
+On Arch Linux, age is available in the official repositories:
 
 ```bash
-git clone https://aur.archlinux.org/age.git
-cd age
-makepkg -si
+sudo pacman -Syu age
 ```
 
 On OpenBSD -current and 6.7+, you can use the port:


### PR DESCRIPTION
I've moved age to the official repositories: https://archlinux.org/packages/community/x86_64/age/

