### PR TITLE
Use golang.org/x/term instead of deprecated package

### DIFF
--- a/cmd/age-keygen/keygen.go
+++ b/cmd/age-keygen/keygen.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"filippo.io/age"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const usage = `Usage:
@@ -127,7 +127,7 @@ func generate(out *os.File) {
 		log.Fatalf("Internal error: %v", err)
 	}
 
-	if !terminal.IsTerminal(int(out.Fd())) {
+	if !term.IsTerminal(int(out.Fd())) {
 		fmt.Fprintf(os.Stderr, "Public key: %s\n", k.Recipient())
 	}
 

--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -20,7 +20,7 @@ import (
 	"filippo.io/age"
 	"filippo.io/age/agessh"
 	"filippo.io/age/armor"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 type multiFlag []string
@@ -186,7 +186,7 @@ func main() {
 		f := newLazyOpener(name)
 		defer f.Close()
 		out = f
-	} else if terminal.IsTerminal(int(os.Stdout.Fd())) {
+	} else if term.IsTerminal(int(os.Stdout.Fd())) {
 		if name != "-" {
 			if decryptFlag {
 				// TODO: buffer the output and check it's printable.
@@ -197,7 +197,7 @@ func main() {
 					`Did you mean to use -a/--armor? Force with "-o -".`)
 			}
 		}
-		if in == os.Stdin && terminal.IsTerminal(int(os.Stdin.Fd())) {
+		if in == os.Stdin && term.IsTerminal(int(os.Stdin.Fd())) {
 			// If the input comes from a TTY and output will go to a TTY,
 			// buffer it up so it doesn't get in the way of typing the input.
 			buf := &bytes.Buffer{}

--- a/cmd/age/encrypted_keys.go
+++ b/cmd/age/encrypted_keys.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	"filippo.io/age"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 type LazyScryptIdentity struct {
@@ -50,7 +50,7 @@ var stdinInUse bool
 
 func readPassphrase() ([]byte, error) {
 	fd := int(os.Stdin.Fd())
-	if !terminal.IsTerminal(fd) || stdinInUse {
+	if !term.IsTerminal(fd) || stdinInUse {
 		tty, err := os.Open("/dev/tty")
 		if err != nil {
 			return nil, fmt.Errorf("standard input is not available or not a terminal, and opening /dev/tty failed: %v", err)
@@ -59,7 +59,7 @@ func readPassphrase() ([]byte, error) {
 		fd = int(tty.Fd())
 	}
 	defer fmt.Fprintf(os.Stderr, "\n")
-	p, err := terminal.ReadPassword(fd)
+	p, err := term.ReadPassword(fd)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module filippo.io/age
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+require (
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
+)


### PR DESCRIPTION
According to the [documentation of golang.org/x/crypto/ssh/terminal](https://pkg.go.dev/golang.org/x/crypto/ssh/terminal) this package has been deprecated and golang.org/x/term should be used instead.