### PR TITLE
Drop system upgrade args from Arch Linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Keep in mind that people might not protect SSH keys long-term, since they are re
     <tr>
         <td>Arch Linux</td>
         <td>
-            <code>pacman -Syu age</code>
+            <code>pacman -S age</code>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
The extra `-yu` arguments here don't belong on a command to install a specific package. Just `-S` is correct to install a single package. The `-u` upgrades all the rest of the packages on the system, something the user may or may not want to do at that moment. The `-y` updates the package indexes, but because Arch does not support partial updates that should **not** be run except when doing a system update. To install a single package at the version that matches your current system just sync the package using the index you have. If you have an old index and do need to update, that's something Arch expects you to understand and do on your own.