### PR TITLE
cmd/age: use CONIN$ instead of /dev/tty on Windows

### DIFF
--- a/cmd/age/read_password_unix.go
+++ b/cmd/age/read_password_unix.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+)
+
+func readPassphraseFromTerminal() ([]byte, error) {
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return nil, fmt.Errorf("opening /dev/tty failed: %v", err)
+	}
+	defer tty.Close()
+	defer fmt.Fprintf(os.Stderr, "\n")
+	return term.ReadPassword(int(tty.Fd()))
+}

--- a/cmd/age/read_password_windows.go
+++ b/cmd/age/read_password_windows.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/term"
+)
+
+func readPassphraseFromTerminal() ([]byte, error) {
+	conin, err := windows.UTF16PtrFromString("CONIN$")
+	if err != nil {
+		return nil, err
+	}
+	tty, err := windows.CreateFile(conin, windows.GENERIC_READ|windows.GENERIC_WRITE, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening CONIN$ failed: %v", err)
+	}
+	defer windows.CloseHandle(tty)
+	defer fmt.Fprintf(os.Stderr, "\n")
+	return term.ReadPassword(int(tty))
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	filippo.io/edwards25519 v1.0.0-beta.3
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 )


### PR DESCRIPTION
I'm intending to solve #128 with this pull request.

The solution for Windows was kindly provided to me by @alexbrainman at https://github.com/golang/go/issues/46164#issuecomment-851329885.

I have to admit, though, that I do not fully understand what is going on, because I am unfamiliar with Windows and it's APIs. As far as I understood using `CONIN$` is also what is [recommended by Microsoft](https://docs.microsoft.com/en-us/windows/console/console-handles):

> The **CreateFile** function enables a process to get a handle to its console's input buffer and active screen buffer, even if `STDIN` and `STDOUT` have been redirected. To open a handle to a console's input buffer, specify the `CONIN$` value in a call to CreateFile. Specify the `CONOUT$` value in a call to **CreateFile** to open a handle to a console's active screen buffer. **CreateFile** enables you to specify the read/write access of the handle that it returns.