### PR TITLE
Add Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Keep in mind that people might not protect SSH keys long-term, since they are re
             <code>xbps-install age</code>
         </td>
     </tr>
+    <tr>
+        <td>Docker</td>
+        <td>
+            <code>docker pull jauderho/age:latest</code>
+        </td>
+    </tr>
 </table>
 
 On Windows, Linux, macOS, and FreeBSD you can use the pre-built binaries.


### PR DESCRIPTION
Add option to use Docker image.

Source Dockerfile is here: https://github.com/jauderho/dockerfiles/blob/main/age/Dockerfile

Supported variants: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6, linux/ppc64le

Images will be built whenever you tag a new release. HTH.