### PR TITLE
Introduce release signing action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,27 @@ jobs:
             curl "https://golang.org/LICENSE?m=text" >> "$DIR/age/LICENSE"
             go build -o "$DIR/age" -ldflags "-X main.Version=$VERSION" ./cmd/...
             if [ "$GOOS" == "windows" ]; then
+              if [ "${{ github.event_name }}" == "release" ]; then
+                echo "Release detected: Signing binaries"
+                echo "${{ secrets.SIGN_CERT }}" >> "$DIR/cert.crt"
+                echo "${{ secrets.SIGN_KEY }}" >> "$DIR/cert.key"
+                /usr/bin/osslsigncode sign -certs "$DIR/cert.crt" -key "$DIR/cert.key" \
+                 -pass "${{ secrets.SIGN_PASS }}" -n "age" -t "http://timestamp.digicert.com" \
+                 -in "$DIR/age/age.exe" -out "$DIR/age/age-signed.exe"
+                /usr/bin/osslsigncode sign -certs "$DIR/cert.crt" -key "$DIR/cert.key" \
+                 -pass "${{ secrets.SIGN_PASS }}" -n "age" -t "http://timestamp.digicert.com" \
+                 -in "$DIR/age/age-keygen.exe" -out "$DIR/age/age-keygen-signed.exe"
+                 rm "$DIR/cert.crt" "$DIR/cert.key" "$DIR/age/age.exe" "$DIR/age/age-keygen.exe"
+                 mv "$DIR/age/age-keygen-signed.exe" "$DIR/age/age-keygen.exe"
+                 mv "$DIR/age/age-signed.exe" "$DIR/age/age.exe"
+              fi
               ( cd "$DIR"; zip age.zip -r age )
               mv "$DIR/age.zip" "age-$VERSION-$GOOS-$GOARCH.zip"
             else
               tar -cvzf "age-$VERSION-$GOOS-$GOARCH.tar.gz" -C "$DIR" age
             fi
           }
+          sudo apt update && sudo apt install -y osslsigncode
           export CGO_ENABLED=0
           GOOS=linux GOARCH=amd64 build_age
           GOOS=linux GOARCH=arm GOARM=6 build_age


### PR DESCRIPTION
This action allows a fix #326.

This script detects release actions and makes no change to the process on standard push events. You can see it produced a release signed with my key here:

https://github.com/technion/age/releases/download/v2.5/age-v2.5-windows-amd64.zip

You can see here that the signature validates and the code runs on my locked down environment, with no Windows Smartscreen warnings or other difficulties:

![image](https://user-images.githubusercontent.com/1948596/132673993-5521827b-6743-43a8-8f5e-630de64e286a.png)

I've run this script through Shellcheck  - it complains because it doesn't understand the Github variable templating but I made sure no other significant issues were presented.

To operate this action, you will need to setup the following Github secrets for the certificate:

![image](https://user-images.githubusercontent.com/1948596/132674481-ba7a92a1-8d4f-482c-8d5c-8ec2c9fbdce0.png)

I wasn't able to avoid writing the certificate to disk, but I made an effort to delete it as soon as it's used, and it's never accessed in plaintext as the action is designed to require a pass key. It also obtains a timestamp signature so you could consider short term keys and produce long term accepted signatures.