### PR TITLE
add mlockall syscall for linux

### DIFF
--- a/cmd/age-keygen/keygen.go
+++ b/cmd/age-keygen/keygen.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"filippo.io/age"
+  _ "filippo.io/age/internal/mlockall"
 	"golang.org/x/term"
 )
 

--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -20,6 +20,7 @@ import (
 	"filippo.io/age"
 	"filippo.io/age/agessh"
 	"filippo.io/age/armor"
+  _ "filippo.io/age/internal/mlockall"
 	"golang.org/x/term"
 )
 

--- a/internal/mlockall/mlockall.go
+++ b/internal/mlockall/mlockall.go
@@ -1,0 +1,5 @@
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package mlockall

--- a/internal/mlockall/mlockall_linux.go
+++ b/internal/mlockall/mlockall_linux.go
@@ -1,0 +1,17 @@
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package mlockall
+
+import (
+	"log"
+	"syscall"
+)
+
+func init() {
+	if err := syscall.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE); err != nil {
+		log.Println(err)
+		log.Fatal("Can't lock memory pages in RAM, it's unsafe to run age")
+	}
+}


### PR DESCRIPTION
By default, OS can copy memory pages with passwords, secret keys etc to
the swap file/volume. And swap files are typically not protected, which
means that attacker can easily restore this information.

Mlockall syscall instructs Linux to keep age memory pages in RAM and
never cache them. This eliminates vulnerability described above.