### PR TITLE
Read passphrase from AGE_PASSPHRASE env var if available

### DIFF
--- a/cmd/age/age.go
+++ b/cmd/age/age.go
@@ -227,6 +227,10 @@ func main() {
 }
 
 func passphrasePromptForEncryption() (string, error) {
+	if pass, exists := os.LookupEnv("AGE_PASSPHRASE"); exists {
+		fmt.Fprintln(os.Stderr, "Using passphrase from environment variable.")
+		return pass, nil
+	}
 	pass, err := readPassphrase("Enter passphrase (leave empty to autogenerate a secure one):")
 	if err != nil {
 		return "", fmt.Errorf("could not read passphrase: %v", err)


### PR DESCRIPTION
From jjlin's own forked commit of age that allows env var to supply the passphrase for automated encryption processes

https: //github.com/jjlin/age/commit/2afaf7fda78117f1e0b784a8c41f9dea15028316
Co-Authored-By: Jeremy Lin <203380+jjlin@users.noreply.github.com>