### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/age_test.go
+++ b/age_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -144,7 +143,7 @@ func TestEncryptDecryptX25519(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	outBytes, err := ioutil.ReadAll(out)
+	outBytes, err := io.ReadAll(out)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +180,7 @@ func TestEncryptDecryptScrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	outBytes, err := ioutil.ReadAll(out)
+	outBytes, err := io.ReadAll(out)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/armor/armor_test.go
+++ b/armor/armor_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"strings"
 	"testing"
@@ -121,7 +120,7 @@ func testArmor(t *testing.T, size int) {
 	}
 
 	r := armor.NewReader(buf)
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/age/age_test.go
+++ b/cmd/age/age_test.go
@@ -6,7 +6,7 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +18,7 @@ import (
 func TestVectors(t *testing.T) {
 	var defaultIDs []age.Identity
 
-	password, err := ioutil.ReadFile("testdata/default_password.txt")
+	password, err := os.ReadFile("testdata/default_password.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestVectors(t *testing.T) {
 			if err == nil {
 				identities = ids
 			}
-			password, err := ioutil.ReadFile("testdata/" + name + "_password.txt")
+			password, err := os.ReadFile("testdata/" + name + "_password.txt")
 			if err == nil {
 				p := strings.TrimSpace(string(password))
 				i, err := age.NewScryptIdentity(p)
@@ -81,7 +81,7 @@ func TestVectors(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				out, err := ioutil.ReadAll(r)
+				out, err := io.ReadAll(r)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmd/age/parse.go
+++ b/cmd/age/parse.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -153,7 +152,7 @@ func parseIdentitiesFile(name string) ([]age.Identity, error) {
 			r = armor.NewReader(r)
 		}
 		const privateKeySizeLimit = 1 << 24 // 16 MiB
-		contents, err := ioutil.ReadAll(io.LimitReader(r, privateKeySizeLimit))
+		contents, err := io.ReadAll(io.LimitReader(r, privateKeySizeLimit))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %q: %v", name, err)
 		}
@@ -177,7 +176,7 @@ func parseIdentitiesFile(name string) ([]age.Identity, error) {
 	// Another PEM file, possibly an SSH private key.
 	case strings.HasPrefix(peeked, "-----BEGIN"):
 		const privateKeySizeLimit = 1 << 14 // 16 KiB
-		contents, err := ioutil.ReadAll(io.LimitReader(b, privateKeySizeLimit))
+		contents, err := io.ReadAll(io.LimitReader(b, privateKeySizeLimit))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %q: %v", name, err)
 		}
@@ -239,7 +238,7 @@ Use a file for which the corresponding ".pub" file exists, or convert the privat
 Ensure %q exists, or convert the private key %q to a modern format with "ssh-keygen -p -m RFC4716"`, name, err, name+".pub", name)
 	}
 	defer f.Close()
-	contents, err := ioutil.ReadAll(f)
+	contents, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %q: %v", name+".pub", err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since age has been upgraded to Go 1.17 in 36b0a4f6117c9ee7210207a69de2eab36b650869, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.