### PR TITLE
Skip signing if key pass isn't available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,16 @@ jobs:
             cp "$RUNNER_TEMP/LICENSE" "$DIR/age"
             go build -o "$DIR/age" -ldflags "-X main.Version=$VERSION" -trimpath ./cmd/...
             if [ "$GOOS" == "windows" ]; then
-              for exe in "$DIR"/age/*.exe; do
-                /usr/bin/osslsigncode sign -t "http://timestamp.comodoca.com" \
-                  -certs .github/workflows/certs/uitacllc.crt \
-                  -key .github/workflows/certs/uitacllc.key \
-                  -pass "${{ secrets.SIGN_PASS }}" \
-                  -n age -in "$exe" -out "$exe.signed"
-                mv "$exe.signed" "$exe"
-              done
+              if [ -n "${{ secrets.SIGN_PASS }}" ]; then
+                for exe in "$DIR"/age/*.exe; do
+                  /usr/bin/osslsigncode sign -t "http://timestamp.comodoca.com" \
+                    -certs .github/workflows/certs/uitacllc.crt \
+                    -key .github/workflows/certs/uitacllc.key \
+                    -pass "${{ secrets.SIGN_PASS }}" \
+                    -n age -in "$exe" -out "$exe.signed"
+                  mv "$exe.signed" "$exe"
+                done
+              fi
               ( cd "$DIR"; zip age.zip -r age )
               mv "$DIR/age.zip" "age-$VERSION-$GOOS-$GOARCH.zip"
             else


### PR DESCRIPTION
Environmental secrets are not shared to workflows run from forks without extra work by Maintainers. 

The existing build workflow uses a secret to sign windows exe's and is breaking for all external PRs. 

Builds are also probably unnecessary for PRs.

See: https://github.com/FiloSottile/age/pull/353#issuecomment-997159334