### PR TITLE
Add Scoop package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ Keep in mind that people might not protect SSH keys long-term, since they are re
             <code>choco install age.portable</code>
         </td>
     </tr>
+    <tr>
+        <td>Scoop (Windows)</td>
+        <td>
+            <code>scoop bucket add extras; scoop install age</code>
+        </td>
+    </tr>
 </table>
 
 On Windows, Linux, macOS, and FreeBSD you can use the pre-built binaries.


### PR DESCRIPTION
[Scoop](https://scoop.sh/) is a package manager for Windows, similar to Chocolatey. However, Scoop installs as the user instead of as admin, and installs binaries in custom locations such as ~\scoop\apps instead of C:\Program Files etc. 