### PR TITLE
cmd/age-keygen: errorf calls os.exit

### DIFF
--- a/cmd/age-keygen/keygen.go
+++ b/cmd/age-keygen/keygen.go
@@ -154,6 +154,7 @@ func convert(in io.Reader, out io.Writer) {
 
 func errorf(format string, v ...interface{}) {
 	log.Printf("age-keygen: error: "+format, v...)
+	log.Fatalf("age-keygen: report unexpected or unhelpful errors at https://filippo.io/age/report")
 }
 
 func warning(msg string) {


### PR DESCRIPTION
Shouldn't this function call os.exit as age errorf does?

https://github.com/FiloSottile/age/blob/e4ae4cf884753cbed766b9522902c2a9dd556468/cmd/age/age.go#L409

 