### PR TITLE
age: add --perm flag to set permissions on output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
     -e, --encrypt               Encrypt the input to the output. Default if omitted.
     -d, --decrypt               Decrypt the input to the output.
     -o, --output OUTPUT         Write the result to the file at path OUTPUT.
+        --perm PERM             Set the permissions of OUTPUT to PERM.
     -a, --armor                 Encrypt to a PEM encoded format.
     -p, --passphrase            Encrypt with a passphrase.
     -r, --recipient RECIPIENT   Encrypt to the specified RECIPIENT. Can be repeated.


### PR DESCRIPTION
age currently writes files with permissions 666&^umask, which typically
result in permissions 664 or 644, i.e. world- and group-readable.

If the file should not be world- or group-readable then an extra chmod
command is required, but there is a short window between age writing the
file and updating the permissions.

This commit adds a --perm flag that allows the permissions to be set on
the output file at creation.