### PR TITLE
Improve error message for old header format

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -189,7 +189,7 @@ func Parse(input io.Reader) (*Header, io.Reader, error) {
 
 		if bytes.HasPrefix(line, footerPrefix) {
 			if r != nil {
-				return nil, nil, errorf("malformed body line %q: reached footer without previous stanza being closed\nNote: this might be a file encrypted with an old beta version of rage. Use rage to decrypt it.", line)
+				return nil, nil, errorf("malformed body line %q: reached footer without previous stanza being closed\nNote: this might be a file encrypted with an old beta version of age or rage. Use age v1.0.0-beta6 or rage to decrypt it.", line)
 			}
 			prefix, args := splitArgs(line)
 			if prefix != string(footerPrefix) || len(args) != 1 {
@@ -203,7 +203,7 @@ func Parse(input io.Reader) (*Header, io.Reader, error) {
 
 		} else if bytes.HasPrefix(line, recipientPrefix) {
 			if r != nil {
-				return nil, nil, errorf("malformed body line %q: new stanza started without previous stanza being closed\nNote: this might be a file encrypted with an old beta version of rage. Use rage to decrypt it.", line)
+				return nil, nil, errorf("malformed body line %q: new stanza started without previous stanza being closed\nNote: this might be a file encrypted with an old beta version of age or rage. Use age v1.0.0-beta6 or rage to decrypt it.", line)
 			}
 			r = &Stanza{}
 			prefix, args := splitArgs(line)


### PR DESCRIPTION
### Closes #397

Not sure if it's a good idea to include the last `age` version that is able to decrypt this kind of messages, but it seemed useful to me. Feel free to update this proposal to match the project style.