### PR TITLE
Improve Nix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Keep in mind that people might not protect SSH keys long-term, since they are re
     <tr>
         <td>NixOS / Nix</td>
         <td>
-            <code>nix-env -i age</code>
+            <code>nix-env -f '<nixpkgs>' -iA age</code>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
The current install command for Nix (`nix-env -i age`) is inefficient because it evaluates all of nixpkgs before installing, this is slow and unnecessary.

Changing to `nix-env -f '<nixpkgs>' -iA age` only evaluates the age attribute and is therefore much quicker.