### PR TITLE
cmd/age: also fallback to stdin and stdout, if /dev/tty exists, but cannot be opened

### DIFF
--- a/cmd/age/encrypted_keys.go
+++ b/cmd/age/encrypted_keys.go
@@ -119,11 +119,7 @@ func readPassphrase(prompt string) ([]byte, error) {
 			return nil, err
 		}
 		defer out.Close()
-	} else if _, err := os.Stat("/dev/tty"); err == nil {
-		tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-		if err != nil {
-			return nil, err
-		}
+	} else if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
 		defer tty.Close()
 		in, out = tty, tty
 	} else {


### PR DESCRIPTION
As mention here [0], I had a problem when /dev/tty exists, but age failed to open it. Now age falls back to /dev/tty, which is the same behavior as if /dev/tty does not exist.
If there are additional changes needed, I am happy to implement them.

PS: Thank you very much for this great tool!

[0] https://github.com/FiloSottile/age/issues/279#issuecomment-1115499664