### PR TITLE
.github/workflows: change Go LICENSE URL from golang.org to go.dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y osslsigncode
           cp LICENSE "$RUNNER_TEMP/LICENSE"
           echo -e "\n---\n" >> "$RUNNER_TEMP/LICENSE"
-          curl "https://go.dev/LICENSE?m=text" >> "$RUNNER_TEMP/LICENSE"
+          curl -L "https://go.dev/LICENSE?m=text" >> "$RUNNER_TEMP/LICENSE"
           VERSION="$(git describe --tags)"
           function build_age() {
             DIR="$(mktemp -d)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y osslsigncode
           cp LICENSE "$RUNNER_TEMP/LICENSE"
           echo -e "\n---\n" >> "$RUNNER_TEMP/LICENSE"
-          curl "https://golang.org/LICENSE?m=text" >> "$RUNNER_TEMP/LICENSE"
+          curl "https://go.dev/LICENSE?m=text" >> "$RUNNER_TEMP/LICENSE"
           VERSION="$(git describe --tags)"
           function build_age() {
             DIR="$(mktemp -d)"


### PR DESCRIPTION
From the release [v1.1.0-rc.1](https://github.com/FiloSottile/age/releases/tag/v1.1.0-rc.1) you can see `<a href="https://go.dev/LICENSE?m=text">Moved Permanently</a>.` at the end of the final (packaged) LICENSE file.

This change addresses this issue.