### PR TITLE
.github/workflows: use gh to upload release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,26 +75,6 @@ jobs:
         with:
           name: age-binaries
       - name: Upload release artifacts
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require("fs").promises;
-            const { repo: { owner, repo }, sha } = context;
-
-            const release = await github.repos.getReleaseByTag({
-              owner, repo,
-              tag: process.env.GITHUB_REF.replace("refs/tags/", ""),
-            });
-            console.log("Release:", { release });
-
-            for (let file of await fs.readdir(".")) {
-              if (!file.startsWith("age-")) continue;
-              console.log("Uploading", file);
-              await github.repos.uploadReleaseAsset({
-                owner, repo,
-                release_id: release.data.id,
-                name: file,
-                data: await fs.readFile(file),
-              });
-            }
+        run: gh release upload "$GITHUB_REF_NAME" age-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,4 +77,5 @@ jobs:
       - name: Upload release artifacts
         run: gh release upload "$GITHUB_REF_NAME" age-*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           path: age-*
   upload:
     name: Upload release binaries
-    if: ${{ github.event_name == 'release' }}
+    if: github.event_name == 'release'
     needs: build
     permissions:
       contents: write


### PR DESCRIPTION
Uses [`gh release upload`](https://cli.github.com/manual/gh_release_upload) for the sake of pipeline code golfing, if that's a thing.