### PR TITLE
Add --inspect flag

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -16,6 +16,7 @@ import (
 )
 
 type Header struct {
+	Version    string
 	Recipients []*Stanza
 	MAC        []byte
 }
@@ -105,7 +106,8 @@ func (w *WrappedBase64Encoder) LastLineIsEmpty() bool {
 	return w.written%ColumnsPerLine == 0
 }
 
-const intro = "age-encryption.org/v1\n"
+const version = "age-encryption.org/v1"
+const intro = version + "\n"
 
 var stanzaPrefix = []byte("->")
 var footerPrefix = []byte("---")
@@ -235,7 +237,7 @@ func errorf(format string, a ...interface{}) error {
 // Parse returns the header and a Reader that begins at the start of the
 // payload.
 func Parse(input io.Reader) (*Header, io.Reader, error) {
-	h := &Header{}
+	h := &Header{Version: version}
 	rr := bufio.NewReader(input)
 
 	line, err := rr.ReadString('\n')


### PR DESCRIPTION
Fixes #56.

```
$ cat recipients.txt
age1lz0vhyg9y3k880cqscuh4hyfv0xdl7qnjqrlcz8euxc4a5d6eagsjhl6vc
age17hxnhlkq9ewhq594s3jf8c2e36n7gfg5mvefn0f3jqsfk76m6geszmywxr
age1ll9j2fr6nsdzmnqwk8qru9nx20sj264978jwswpnwq0nwnj4ayrsyugyqx
age160amxp02vl8w5e4z5tvvcmpdtjhdzkh20s3r9gqtzwufgyucreyqm6vw0y
age1xlauzza8tgn6l7e3ympwkps8tnt9psmpjj6jl0qfnfwkxkn7l4ws3s9xar

$ echo 'Hello age' | go run ./cmd/age -a -R recipients.txt -o encrypted.age.ascii

$ go run ./cmd/age --inspect encrypted.age.ascii | jq .
{
  "RecipientCounts": {
    "X25519": 5
  },
  "Version": "age-encryption.org/v1",
  "PayloadSize": 42
}
```

I've chosen to make the output JSON-encoded because the data that `--inspect` outputs is fairly small, so the JSON is fairly easily readable (even without `jq`), and outputting in JSON makes it machine-readable.

I've read https://github.com/FiloSottile/age/blob/9f0a2d25ac79da8100d68f3e8b3a1a57ea4a73ba/.github/CONTRIBUTING.md and can confirm that I won't be offended if this is reimplemented instead of being merged :smile: 