### PR TITLE
cmd/age-keygen: fix non-constant format string in `log.Printf`

### DIFF
--- a/cmd/age-keygen/keygen.go
+++ b/cmd/age-keygen/keygen.go
@@ -158,5 +158,5 @@ func errorf(format string, v ...interface{}) {
 }
 
 func warning(msg string) {
-	log.Printf("age-keygen: warning: " + msg)
+	log.Print("age-keygen: warning: " + msg)
 }


### PR DESCRIPTION
Discovered on https://github.com/FiloSottile/age/pull/591#issuecomment-2408473434, related to https://github.com/golang/go/issues/60529