### PR TITLE
.github/workflows: enable GitHub artifact attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           GOARM: ${{ matrix.GOARM }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
+        if: github.event_name == 'release'
         with:
           subject-path: age-*
       - name: Upload workflow artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
   push:
   pull_request:
 permissions:
+  attestations: write
   contents: read
+  id-token: write
 jobs:
   build:
     name: Build binaries
@@ -61,6 +63,10 @@ jobs:
           GOOS: ${{ matrix.GOOS }}
           GOARCH: ${{ matrix.GOARCH }}
           GOARM: ${{ matrix.GOARM }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: age-*
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
[GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) are very similar to [Sigsum](https://www.sigsum.org/)[^1] but the signing process is fully automated, and happens in the same GitHub Actions worker that builds the binaries.

Maybe this is a bit redundant, but given how easy it was to configure and how nice the integration with GitHub is, I thought you'd be interested to try it out.

### What will happen after merging/releasing this pull request?

Artifact attestations will be available at https://github.com/FiloSottile/age/attestations, and users will be able to verify the downloaded release artifacts using the `gh` command-line tool:

```console
$ gh attestation verify --owner FiloSottile age-v1.2.2-linux-amd64.tar.gz
Loaded digest sha256:... for file:///.../age-v1.2.2-linux-amd64.tar.gz
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:... was attested by:
REPO             PREDICATE_TYPE                  WORKFLOW
FiloSottile/age  https://slsa.dev/provenance/v1  .github/workflows/build.yml@v1.2.2
```

> [!TIP]
> See https://github.com/0x2b3bfa0/age/attestations/5246743 for a sample attestation in the fork. 🙈 

[^1]: Based on [Sigstore](https://www.sigstore.dev), a project with some shared goals.