### PR TITLE
.github/workflows: fix actions/setup-go cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,14 @@ jobs:
           - {GOOS: windows, GOARCH: amd64}
           - {GOOS: freebsd, GOARCH: amd64}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.x
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.x
       - name: Build binary
         run: |
           cp LICENSE "$RUNNER_TEMP/LICENSE"


### PR DESCRIPTION
Running `actions/setup-go` before `actions/checkout` was preventing the former from using `go.sum` to cache dependencies, as it wasn't still present in the working directory:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/age/age. Supported file pattern: go.sum
```

## [Sample workflow run](https://github.com/FiloSottile/age/actions/runs/13583113716)

![Captura de pantalla 2025-02-28 a las 8 16 06](https://github.com/user-attachments/assets/3a7a90a4-60a7-4990-bd0f-91c437eafcf2)
