### PR TITLE
.github/workflows: fix `gotip` tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,13 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           git clone --filter=tree:0 https://go.googlesource.com/go $HOME/gotip
-          $env:GOROOT_BOOTSTRAP = (go env GOROOT)
           cd $HOME/gotip/src && ./make.bash
           echo "$HOME/gotip/bin" >> $GITHUB_PATH
       - name: Install Go tip (Windows)
         if: runner.os == 'Windows'
         run: |
           git clone --filter=tree:0 https://go.googlesource.com/go $HOME/gotip
+          $env:GOROOT_BOOTSTRAP = (go env GOROOT)
           cd $HOME/gotip/src && ./make.bat
           echo "$HOME/gotip/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           git clone --filter=tree:0 https://go.googlesource.com/go $HOME/gotip
+          $env:GOROOT_BOOTSTRAP = (go env GOROOT)
           cd $HOME/gotip/src && ./make.bash
           echo "$HOME/gotip/bin" >> $GITHUB_PATH
       - name: Install Go tip (Windows)


### PR DESCRIPTION
Default GitHub Actions Windows runners ship with several Go versions installed out of the box; `$env:PATH` contains `C:\hostedtoolcache\windows\go\1.21.13\x64\bin` by default.

While [`actions/setup-go`](https://github.com/FiloSottile/age/blob/aaaaf4ac4e7af9cd5b3c8ac56872bc85f7100f51/.github/workflows/test.yml#L33-L36) installs Go 1.24.0 ([stable](https://github.com/actions/go-versions/blob/21413175ac3713f8289fa15134a683398613806b/versions-manifest.json#L3-L4)) and prepends `C:\hostedtoolcache\windows\go\1.24.0\x64\bin` to `$env:PATH` as expected, it's not being detected by `make.bat` as the preferred Go version for the bootstrap toolchain.

Due to a bug[^1] in [`src/make.bat`](https://github.com/golang/go/blob/d31c805535f3fde95646ee4d87636aaaea66847b/src/make.bat), the **last** Go in `$env:PATH` will take precedence over the first one, causing `GOROOT_BOOTSTRAP` to use the old Go 1.21.13 instead of 1.24.0.

Since [CL 606156](https://go-review.googlesource.com/c/go/+/606156), Go depends on 1.22.6 or later for bootstrap, and that's why the workflow is broken.

[^1]: See https://go-review.googlesource.com/c/go/+/653535.

