### PR TITLE
internal/inspect: fix tag stanza type names in post-quantum classifier

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -61,9 +61,9 @@ func Inspect(r io.Reader, fileSize int64) (*Metadata, error) {
 	for _, s := range hdr.Recipients {
 		data.StanzaTypes = append(data.StanzaTypes, s.Type)
 		switch s.Type {
-		case "X25519", "ssh-rsa", "ssh-ed25519", "age-encryption.org/p256tag", "piv-p256":
+		case "X25519", "ssh-rsa", "ssh-ed25519", "p256tag", "piv-p256":
 			data.Postquantum = "no"
-		case "mlkem768x25519", "scrypt", "age-encryption.org/mlkem768p256tag":
+		case "mlkem768x25519", "scrypt", "mlkem768p256tag":
 			if data.Postquantum != "no" {
 				data.Postquantum = "yes"
 			}

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -1,11 +1,56 @@
 package inspect
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
+	"filippo.io/age/internal/format"
 	"filippo.io/age/internal/stream"
 )
+
+// buildFile serializes a header with a single stanza of the given type,
+// followed by the minimal valid encrypted payload (a 16-byte stream nonce
+// and a single empty ChaCha20-Poly1305 chunk).
+func buildFile(t *testing.T, stanzaType string) []byte {
+	t.Helper()
+	hdr := &format.Header{
+		Recipients: []*format.Stanza{{Type: stanzaType}},
+		MAC:        make([]byte, 32),
+	}
+	buf := &bytes.Buffer{}
+	if err := hdr.Marshal(buf); err != nil {
+		t.Fatalf("Header.Marshal: %v", err)
+	}
+	// Append nonce (16 bytes) + poly1305 tag for empty chunk (16 bytes).
+	buf.Write(make([]byte, 16+16))
+	return buf.Bytes()
+}
+
+func TestInspectTagStanzas(t *testing.T) {
+	tests := []struct {
+		stanzaType string
+		want       string
+	}{
+		{stanzaType: "p256tag", want: "no"},
+		{stanzaType: "mlkem768p256tag", want: "yes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.stanzaType, func(t *testing.T) {
+			f := buildFile(t, tt.stanzaType)
+			md, err := Inspect(bytes.NewReader(f), int64(len(f)))
+			if err != nil {
+				t.Fatalf("Inspect: %v", err)
+			}
+			if got := md.Postquantum; got != tt.want {
+				t.Errorf("Postquantum = %q, want %q", got, tt.want)
+			}
+			if len(md.StanzaTypes) != 1 || md.StanzaTypes[0] != tt.stanzaType {
+				t.Errorf("StanzaTypes = %v, want [%q]", md.StanzaTypes, tt.stanzaType)
+			}
+		})
+	}
+}
 
 func TestStreamOverhead(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
`Inspect` matched tag stanzas against `"age-encryption.org/p256tag"` and
`"age-encryption.org/mlkem768p256tag"` — those are the HPKE info labels. The
actual stanza types emitted by `tag.WrapWithLabels` are `"p256tag"` and
`"mlkem768p256tag"`, so files encrypted to `age1tag1...` / `age1tagpq1...`
recipients always reported `Postquantum: "unknown"`.

Fix: use the stanza type strings.

Test: `go test ./internal/inspect/ -run TestInspectTagStanzas -v`