### PR TITLE
internal/stream: reject sizes below one tag in EncryptedChunkCount

### DIFF
--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -20,6 +20,9 @@ import (
 const ChunkSize = 64 * 1024
 
 func EncryptedChunkCount(encryptedSize int64) (int64, error) {
+	if encryptedSize < chacha20poly1305.Overhead {
+		return 0, fmt.Errorf("invalid encrypted payload size: %d", encryptedSize)
+	}
 	chunks := (encryptedSize + encChunkSize - 1) / encChunkSize
 
 	plaintextSize := encryptedSize - chunks*chacha20poly1305.Overhead

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -905,6 +905,24 @@ func TestDecryptReaderAtConcurrent(t *testing.T) {
 	})
 }
 
+func TestEncryptedChunkCountRejectsSmallSizes(t *testing.T) {
+	// A valid encrypted payload must carry at least one Poly1305 tag
+	// (chacha20poly1305.Overhead = 16 bytes). Before the fix, sizes below
+	// this threshold silently returned (0, nil) instead of an error.
+	for _, size := range []int64{-1, 0, chacha20poly1305.Overhead - 1} {
+		if n, err := stream.EncryptedChunkCount(size); err == nil {
+			t.Errorf("EncryptedChunkCount(%d) = (%d, nil), want error", size, n)
+		}
+	}
+
+	// Exactly one tag: the empty-plaintext single chunk case.
+	if n, err := stream.EncryptedChunkCount(chacha20poly1305.Overhead); err != nil {
+		t.Errorf("EncryptedChunkCount(%d) returned unexpected error: %v", chacha20poly1305.Overhead, err)
+	} else if n != 1 {
+		t.Errorf("EncryptedChunkCount(%d) = %d, want 1", chacha20poly1305.Overhead, n)
+	}
+}
+
 func TestDecryptReaderAtCorrupted(t *testing.T) {
 	key := make([]byte, chacha20poly1305.KeySize)
 	if _, err := rand.Read(key); err != nil {


### PR DESCRIPTION
`EncryptedChunkCount` returned `(0, nil)` for negative or sub-tag-size inputs —
the consistency check rounds both sides to `0` and passes silently. This would
cascade into `NewDecryptReaderAt` computing `finalChunkIndex = -1`.

Fix: a valid payload always carries at least one Poly1305 tag, even for empty
plaintext. Reject anything smaller than `chacha20poly1305.Overhead` up front.

Test: `go test ./internal/stream/ -run TestEncryptedChunkCountRejectsSmallSizes -v`
