### PR TITLE
all: minor cleanups

### DIFF
--- a/age.go
+++ b/age.go
@@ -130,7 +130,7 @@ func encryptHdr(fileKey []byte, recipients ...Recipient) (*format.Header, error)
 		sort.Strings(l)
 		if i == 0 {
 			labels = l
-		} else if !slicesEqual(labels, l) {
+		} else if !slices.Equal(labels, l) {
 			return nil, incompatibleLabelsError(labels, l)
 		}
 		for _, s := range stanzas {
@@ -206,18 +206,6 @@ func wrapWithLabels(r Recipient, fileKey []byte) (s []*Stanza, labels []string, 
 	}
 	s, err = r.Wrap(fileKey)
 	return
-}
-
-func slicesEqual(s1, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func incompatibleLabelsError(l1, l2 []string) error {

--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -21,7 +21,7 @@ type Metadata struct {
 		Header   int64 `json:"header"`
 		Armor    int64 `json:"armor"`
 		Overhead int64 `json:"overhead"`
-		// Currently, we don't do any padding, not MinPayload == MaxPayload and
+		// Currently, we don't do any padding, so MinPayload == MaxPayload and
 		// MinPadding == MaxPadding == 0, but that might change in the future.
 		MinPayload int64 `json:"min_payload"`
 		MaxPayload int64 `json:"max_payload"`

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,6 +1,6 @@
 // Package plugin implements the age plugin protocol.
 //
-// [Recipient] and [Indentity] are plugin clients, that execute plugin binaries to
+// [Recipient] and [Identity] are plugin clients, that execute plugin binaries to
 // perform encryption and decryption operations.
 //
 // [Plugin] is a framework for writing age plugins, that exposes an [age.Recipient]
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 
 	"filippo.io/age"
@@ -358,7 +359,7 @@ func wrapWithLabels(r age.Recipient, fileKey []byte) ([]*age.Stanza, []string, e
 }
 
 func checkLabels(ll, labels []string) error {
-	if !slicesEqual(ll, labels) {
+	if !slices.Equal(ll, labels) {
 		return fmt.Errorf("labels %q do not match previous recipients %q", ll, labels)
 	}
 	return nil
@@ -661,16 +662,4 @@ func (p *Plugin) writeError(args []string, err error) error {
 		return fmt.Errorf("%v", err)
 	}
 	return nil
-}
-
-func slicesEqual(s1, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Replace two hand-rolled slicesEqual helpers with slices.Equal from the standard library, which is already imported in age.go. (age.go:211-221, plugin/plugin.go:666-676)

Fix godoc link typo [Indentity] -> [Identity].
(plugin/plugin.go:3)

Fix comment typo "not MinPayload" -> "so MinPayload". (internal/inspect/inspect.go:25)