### PR TITLE
feat: x25519 tag and mlkem768x25519 tagpq support

### DIFF
--- a/tag/tag.go
+++ b/tag/tag.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package tag implements tagged P-256 or hybrid P-256 + ML-KEM-768 recipients,
+// Package tag implements tagged P-256/X25519 or hybrid P-256/X25519 + ML-KEM-768 recipients,
 // which can be used with identities stored on hardware keys, usually supported
 // by dedicated plugins.
 //
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/crypto/curve25519"
 )
 
-// Recipient is a tagged P-256 or hybrid P-256 + ML-KEM-768 recipient.
+// Recipient is a tagged P-256/X25519 or hybrid P-256/X25519 + ML-KEM-768 recipient.
 //
 // The latter recipient is safe against future cryptographically-relevant
 // quantum computers, and can only be used along with other post-quantum
@@ -67,7 +67,7 @@ func ParseRecipient(s string) (*Recipient, error) {
 const compressedPointSize = 1 + 32
 const uncompressedPointSize = 1 + 32 + 32
 
-// NewClassicRecipient returns a new P-256 [Recipient] from a raw public key.
+// NewClassicRecipient returns a new P-256/X25519 [Recipient] from a raw public key.
 func NewClassicRecipient(publicKey []byte) (*Recipient, error) {
 	var k hpke.PublicKey
 	var err error
@@ -136,7 +136,7 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 			}
 		case hpke.MLKEM768X25519().ID():
 			label = "age-encryption.org/mlkem768x25519tag"
-			// In hybrid mode, the tag is computed over just the P-256 part.
+			// In hybrid mode, the tag is computed over just the X25519 part.
 			tagRecipient = tagRecipient[mlkem.EncapsulationKeySize768:]
 			if len(enc) != mlkem.CiphertextSize768+curve25519.PointSize {
 				return nil, fmt.Errorf("invalid ciphertext size")
@@ -161,7 +161,7 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 }
 
 // WrapWithLabels implements [age.RecipientWithLabels], returning a single
-// "postquantum" label if r is a hybrid P-256 + ML-KEM-768 recipient. This
+// "postquantum" label if r is a hybrid P-256/X25519 + ML-KEM-768 recipient. This
 // ensures a hybrid Recipient can't be mixed with other recipients that would
 // defeat its post-quantum security.
 //

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -124,7 +124,7 @@ func (r *Recipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 // identities compatible with tagged recipients.
 func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 	var label string
-	var tagRecipient []byte
+	tagRecipient := r.Bytes()
 	if r.Hybrid() {
 		switch r.pk.KEM().ID() {
 		case hpke.MLKEM768P256().ID():
@@ -142,13 +142,10 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 				return nil, fmt.Errorf("invalid ciphertext size")
 			}
 		}
-	} else if len(r.pk.Bytes()) == compressedPointSize {
-		if len(enc) != uncompressedPointSize {
-			return nil, fmt.Errorf("invalid ciphertext size")
-		}
-		label, tagRecipient = "age-encryption.org/p256tag", r.Bytes()
 	} else if len(enc) == curve25519.PointSize {
-		label, tagRecipient = "age-encryption.org/x25519tag", r.Bytes()
+		label = "age-encryption.org/x25519tag"
+	} else if len(enc) == uncompressedPointSize {
+		label = "age-encryption.org/p256tag"
 	} else {
 		return nil, fmt.Errorf("invalid ciphertext size")
 	}
@@ -176,10 +173,10 @@ func (r *Recipient) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, err
 		case hpke.MLKEM768X25519().ID():
 			label, arg = "age-encryption.org/mlkem768x25519tag", "mlkem768x25519tag"
 		}
-	} else if len(r.pk.Bytes()) == compressedPointSize {
-		label, arg = "age-encryption.org/p256tag", "p256tag"
-	} else {
+	} else if len(r.pk.Bytes()) == curve25519.PointSize {
 		label, arg = "age-encryption.org/x25519tag", "x25519tag"
+	} else {
+		label, arg = "age-encryption.org/p256tag", "p256tag"
 	}
 
 	enc, s, err := hpke.NewSender(r.pk, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), []byte(label))

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -65,6 +65,7 @@ func ParseRecipient(s string) (*Recipient, error) {
 
 const compressedPointSize = 1 + 32
 const uncompressedPointSize = 1 + 32 + 32
+const x25519Size = 32
 
 // NewClassicRecipient returns a new P-256 [Recipient] from a raw public key.
 func NewClassicRecipient(publicKey []byte) (*Recipient, error) {
@@ -82,19 +83,26 @@ func NewClassicRecipient(publicKey []byte) (*Recipient, error) {
 	return &Recipient{k}, nil
 }
 
-// NewHybridRecipient returns a new hybrid P-256 + ML-KEM-768 [Recipient] from
+// NewHybridRecipient returns a new hybrid P-256/X25519 + ML-KEM-768 [Recipient] from
 // raw concatenated public keys.
 func NewHybridRecipient(publicKey []byte) (*Recipient, error) {
-	k, err := hpke.MLKEM768P256().NewPublicKey(publicKey)
+	var k hpke.PublicKey
+	var err error
+	if len(publicKey) == 1216 {
+		k, err = hpke.MLKEM768X25519().NewPublicKey(publicKey)
+	} else {
+		k, err = hpke.MLKEM768P256().NewPublicKey(publicKey)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("invalid tagpq recipient public key: %v", err)
 	}
 	return &Recipient{k}, nil
 }
 
-// Hybrid reports whether r is a hybrid P-256 + ML-KEM-768 recipient.
+// Hybrid reports whether r is a hybrid P-256/X25519 + ML-KEM-768 recipient.
 func (r *Recipient) Hybrid() bool {
-	return r.pk.KEM().ID() == hpke.MLKEM768P256().ID()
+	hybridIds := []uint16{hpke.MLKEM768P256().ID(), hpke.MLKEM768X25519().ID()}
+	return slices.Contains(hybridIds, r.pk.KEM().ID())
 }
 
 func (r *Recipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
@@ -109,11 +117,21 @@ func (r *Recipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 	label, tagRecipient := "age-encryption.org/p256tag", r.Bytes()
 	if r.Hybrid() {
-		label = "age-encryption.org/mlkem768p256tag"
-		// In hybrid mode, the tag is computed over just the P-256 part.
-		tagRecipient = tagRecipient[mlkem.EncapsulationKeySize768:]
-		if len(enc) != mlkem.CiphertextSize768+uncompressedPointSize {
-			return nil, fmt.Errorf("invalid ciphertext size")
+		switch r.pk.KEM().ID() {
+		case hpke.MLKEM768P256().ID():
+			label = "age-encryption.org/mlkem768p256tag"
+			// In hybrid mode, the tag is computed over just the P-256 part.
+			tagRecipient = tagRecipient[mlkem.EncapsulationKeySize768:]
+			if len(enc) != mlkem.CiphertextSize768+uncompressedPointSize {
+				return nil, fmt.Errorf("invalid ciphertext size")
+			}
+		case hpke.MLKEM768X25519().ID():
+			label = "age-encryption.org/mlkem768x25519tag"
+			// In hybrid mode, the tag is computed over just the P-256 part.
+			tagRecipient = tagRecipient[mlkem.EncapsulationKeySize768:]
+			if len(enc) != mlkem.CiphertextSize768+x25519Size {
+				return nil, fmt.Errorf("invalid ciphertext size")
+			}
 		}
 	} else if len(enc) != uncompressedPointSize {
 		return nil, fmt.Errorf("invalid ciphertext size")
@@ -136,7 +154,12 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 func (r *Recipient) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, error) {
 	label, arg := "age-encryption.org/p256tag", "p256tag"
 	if r.Hybrid() {
-		label, arg = "age-encryption.org/mlkem768p256tag", "mlkem768p256tag"
+		switch r.pk.KEM().ID() {
+		case hpke.MLKEM768P256().ID():
+			label, arg = "age-encryption.org/mlkem768p256tag", "mlkem768p256tag"
+		case hpke.MLKEM768X25519().ID():
+			label, arg = "age-encryption.org/mlkem768x25519tag", "mlkem768x25519tag"
+		}
 	}
 
 	enc, s, err := hpke.NewSender(r.pk, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), []byte(label))

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -25,6 +25,7 @@ import (
 	"filippo.io/age/plugin"
 	"filippo.io/hpke"
 	"filippo.io/nistec"
+	"golang.org/x/crypto/curve25519"
 )
 
 // Recipient is a tagged P-256 or hybrid P-256 + ML-KEM-768 recipient.
@@ -65,20 +66,27 @@ func ParseRecipient(s string) (*Recipient, error) {
 
 const compressedPointSize = 1 + 32
 const uncompressedPointSize = 1 + 32 + 32
-const x25519Size = 32
 
 // NewClassicRecipient returns a new P-256 [Recipient] from a raw public key.
 func NewClassicRecipient(publicKey []byte) (*Recipient, error) {
-	if len(publicKey) != compressedPointSize {
+	var k hpke.PublicKey
+	var err error
+	if len(publicKey) == curve25519.PointSize {
+		k, err = hpke.DHKEM(ecdh.X25519()).NewPublicKey(publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tag recipient public key: %v", err)
+		}
+	} else if len(publicKey) == compressedPointSize {
+		p, err := nistec.NewP256Point().SetBytes(publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tag recipient public key: %v", err)
+		}
+		k, err = hpke.DHKEM(ecdh.P256()).NewPublicKey(p.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("invalid tag recipient public key: %v", err)
+		}
+	} else {
 		return nil, fmt.Errorf("invalid tag recipient public key size %d", len(publicKey))
-	}
-	p, err := nistec.NewP256Point().SetBytes(publicKey)
-	if err != nil {
-		return nil, fmt.Errorf("invalid tag recipient public key: %v", err)
-	}
-	k, err := hpke.DHKEM(ecdh.P256()).NewPublicKey(p.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf("invalid tag recipient public key: %v", err)
 	}
 	return &Recipient{k}, nil
 }
@@ -115,7 +123,8 @@ func (r *Recipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 // This is a low-level method exposed for use by plugins that implement
 // identities compatible with tagged recipients.
 func (r *Recipient) Tag(enc []byte) ([]byte, error) {
-	label, tagRecipient := "age-encryption.org/p256tag", r.Bytes()
+	var label string
+	var tagRecipient []byte
 	if r.Hybrid() {
 		switch r.pk.KEM().ID() {
 		case hpke.MLKEM768P256().ID():
@@ -129,11 +138,18 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 			label = "age-encryption.org/mlkem768x25519tag"
 			// In hybrid mode, the tag is computed over just the P-256 part.
 			tagRecipient = tagRecipient[mlkem.EncapsulationKeySize768:]
-			if len(enc) != mlkem.CiphertextSize768+x25519Size {
+			if len(enc) != mlkem.CiphertextSize768+curve25519.PointSize {
 				return nil, fmt.Errorf("invalid ciphertext size")
 			}
 		}
-	} else if len(enc) != uncompressedPointSize {
+	} else if len(r.pk.Bytes()) == compressedPointSize {
+		if len(enc) != uncompressedPointSize {
+			return nil, fmt.Errorf("invalid ciphertext size")
+		}
+		label, tagRecipient = "age-encryption.org/p256tag", r.Bytes()
+	} else if len(enc) == curve25519.PointSize {
+		label, tagRecipient = "age-encryption.org/x25519tag", r.Bytes()
+	} else {
 		return nil, fmt.Errorf("invalid ciphertext size")
 	}
 	rh := sha256.Sum256(tagRecipient)
@@ -152,7 +168,7 @@ func (r *Recipient) Tag(enc []byte) ([]byte, error) {
 // To unsafely bypass this restriction, wrap Recipient in an [age.Recipient]
 // type that doesn't expose WrapWithLabels.
 func (r *Recipient) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, error) {
-	label, arg := "age-encryption.org/p256tag", "p256tag"
+	var label, arg string
 	if r.Hybrid() {
 		switch r.pk.KEM().ID() {
 		case hpke.MLKEM768P256().ID():
@@ -160,6 +176,10 @@ func (r *Recipient) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, err
 		case hpke.MLKEM768X25519().ID():
 			label, arg = "age-encryption.org/mlkem768x25519tag", "mlkem768x25519tag"
 		}
+	} else if len(r.pk.Bytes()) == compressedPointSize {
+		label, arg = "age-encryption.org/p256tag", "p256tag"
+	} else {
+		label, arg = "age-encryption.org/x25519tag", "x25519tag"
 	}
 
 	enc, s, err := hpke.NewSender(r.pk, hpke.HKDFSHA256(), hpke.ChaCha20Poly1305(), []byte(label))
@@ -193,7 +213,7 @@ func (r *Recipient) WrapWithLabels(fileKey []byte) ([]*age.Stanza, []string, err
 
 // Bytes returns the raw recipient encoding.
 func (r *Recipient) Bytes() []byte {
-	if r.Hybrid() {
+	if r.Hybrid() || len(r.pk.Bytes()) == curve25519.PointSize {
 		return r.pk.Bytes()
 	}
 	p, err := nistec.NewP256Point().SetBytes(r.pk.Bytes())


### PR DESCRIPTION
This PR would add a new x25519 tag and mlkem768x25519 tagpq recipient to `age-plugin-tag` and `age-plugin-tagpq`. I felt the original tagged recipient spec should have included x25519 based keys as well so that users could convert their original age keys to any type of hardware key they desired. I've also been working on [a branch of the age-plugin-yubikey repo](https://github.com/str4d/age-plugin-yubikey/pull/226) which adds support for these key types too, and have been using this code here as a test for that. Having an officially supported reference spec would be great so that I actually know my code there is aligning well with age as a whole.

Not sure if this is desirable since it does add more complication to age which is supposed to be very simple, but I figure it's worth a discussion especially since it's mostly extending the already existing age keys.