### PR TITLE
fix/enhancement: age-inspect indefinitely hanging and also improvements to usage info and flags for both age-inspect and age-keygen

### DIFF
--- a/cmd/age-inspect/inspect.go
+++ b/cmd/age-inspect/inspect.go
@@ -16,10 +16,12 @@ import (
 )
 
 const usage = `Usage:
+    age-inspect [INPUT]
     age-inspect [--json] [INPUT]
 
 Options:
     --json                      Output machine-readable JSON.
+    -v, --version               Print the version.
 
 INPUT defaults to standard input. "-" may be used as INPUT to explicitly
 read from standard input.`
@@ -36,6 +38,7 @@ func main() {
 		jsonFlag    bool
 	)
 
+	flag.BoolVar(&versionFlag, "v", false, "print the version")
 	flag.BoolVar(&versionFlag, "version", false, "print the version")
 	flag.BoolVar(&jsonFlag, "json", false, "output machine-readable JSON")
 	flag.Parse()
@@ -63,6 +66,18 @@ func main() {
 		defer f.Close()
 		in = f
 		if stat, err := f.Stat(); err == nil && stat.Mode().IsRegular() {
+			fileSize = stat.Size()
+		}
+	} else {
+		stat, err := in.Stat()
+		if err != nil {
+			errorf("failed to stat stdin: %v", err)
+		}
+		if name == "" && (stat.Mode()&os.ModeCharDevice) != 0 {
+			flag.Usage()
+			os.Exit(1)
+		}
+		if stat.Mode().IsRegular() {
 			fileSize = stat.Size()
 		}
 	}

--- a/cmd/age-keygen/keygen.go
+++ b/cmd/age-keygen/keygen.go
@@ -26,6 +26,7 @@ Options:
                               (This might become the default in the future.)
     -o, --output OUTPUT       Write the result to the file at path OUTPUT.
     -y                        Convert an identity file to a recipients file.
+    -v, --version             Print the version.
 
 age-keygen generates a new native X25519 or, with the -pq flag, post-quantum
 hybrid ML-KEM-768 + X25519 key pair, and outputs it to standard output or to
@@ -67,6 +68,7 @@ func main() {
 	var outFlag string
 	var pqFlag, versionFlag, convertFlag bool
 
+	flag.BoolVar(&versionFlag, "v", false, "print the version")
 	flag.BoolVar(&versionFlag, "version", false, "print the version")
 	flag.BoolVar(&pqFlag, "pq", false, "generate a post-quantum key pair")
 	flag.BoolVar(&convertFlag, "y", false, "convert identities to recipients")


### PR DESCRIPTION
This PR mainly ensures correctness on `age-inspect` by fixing an issue where `age-inspect` would hang indefinitely, when invoked alone without arguments or a piped input, and also improves the usage information and version flags a bit for different age CLI binaries. 

- adds a `v` as an alternative version flag to `age-inspect` and `age-keygen`.
- improves the usage information, by adding alternate usage to `age-inspect`.

In relation to age-inspect, the changes I've made wont affect previous behavior.

```sh
$ age-inspect
```
<details>
<summary>Click to expand output</summary>

```
Usage:
    age-inspect [INPUT]
    age-inspect [--json] [INPUT]

Options:
    --json                      Output machine-readable JSON.
    -v, --version               Print the version.

INPUT defaults to standard input. "-" may be used as INPUT to explicitly
read from standard input.
```
</details>

```sh
$ age-inspect test.age
```
<details>
<summary>Click to expand output</summary>

```
test.age is an age file, version "age-encryption.org/v1".

This file is ASCII-armored.

This file is encrypted to the following recipient types:
  - "scrypt"

This file uses post-quantum encryption.

Size breakdown (assuming it decrypts successfully):

    Header                       150 bytes
    Armor overhead              1481 bytes
    Encryption overhead           32 bytes
    Payload                     3805 bytes
                        -------------------
    Total                       5468 bytes

Tip: for machine-readable output, use --json.
```
</details>

```sh
$ age-inspect --json test.age
```
<details>
<summary>Click to expand output</summary>

```json
{
    "version": "age-encryption.org/v1",
    "postquantum": "yes",
    "armor": true,
    "stanza_types": [
        "scrypt"
    ],
    "sizes": {
        "header": 150,
        "armor": 1481,
        "overhead": 32,
        "min_payload": 3805,
        "max_payload": 3805,
        "min_padding": 0,
        "max_padding": 0
    }
}
```
</details>

```sh
$ cat test.age | age-inspect
```
<details>
<summary>Click to expand output</summary>

```
<stdin> is an age file, version "age-encryption.org/v1".

This file is ASCII-armored.

This file is encrypted to the following recipient types:
  - "scrypt"

This file uses post-quantum encryption.

Size breakdown (assuming it decrypts successfully):

    Header                       150 bytes
    Armor overhead              1481 bytes
    Encryption overhead           32 bytes
    Payload                     3805 bytes
                        -------------------
    Total                       5468 bytes

Tip: for machine-readable output, use --json.
```
</details>


```sh
$ cat test.age | age-inspect --json
```
<details>
<summary>Click to expand output</summary>

```json
{
    "version": "age-encryption.org/v1",
    "postquantum": "yes",
    "armor": true,
    "stanza_types": [
        "scrypt"
    ],
    "sizes": {
        "header": 150,
        "armor": 1481,
        "overhead": 32,
        "min_payload": 3805,
        "max_payload": 3805,
        "min_padding": 0,
        "max_padding": 0
    }
}
```
</details>
